### PR TITLE
fix: Exit on `tz` immediately in `rofibatz.sh`

### DIFF
--- a/share/rofibatz.sh
+++ b/share/rofibatz.sh
@@ -11,4 +11,4 @@ elif [[ ${ROFI_RETV} == 1 ]];then
     exit 
 fi
 
-tz|sed -e "s/\x1b\[.\{1,5\}m//g"
+tz -q|sed -e "s/\x1b\[.\{1,5\}m//g"


### PR DESCRIPTION
- `tz` hangs if not `-q` given.